### PR TITLE
feat: enhance project and task hooks with dashboard query invalidation

### DIFF
--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -11,6 +11,7 @@ import type {
   UpdateProjectRequest,
 } from '@/types/project';
 import { taskKeys } from '@/hooks/useTasks';
+import { dashboardKeys } from './useDashboard';
 
 const PROJECT_STALE_TIME = 1000 * 60 * 5; // 5 minutes
 
@@ -59,6 +60,8 @@ export const useCreateProject = () => {
     onSuccess: () => {
       // Invalidate and refetch projects list
       queryClient.invalidateQueries({ queryKey: projectKeys.lists() });
+      // Invalidate dashboard queries (summary and myProjects)
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     },
   });
 };
@@ -77,6 +80,8 @@ export const useUpdateProject = () => {
       // Also invalidate task caches that may denormalize project name on tasks
       queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
       queryClient.invalidateQueries({ queryKey: taskKeys.global() });
+      // Invalidate dashboard queries (summary and myProjects)
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     },
   });
 };
@@ -91,6 +96,8 @@ export const useDeleteProject = () => {
       queryClient.removeQueries({ queryKey: projectKeys.detail(id) });
       // Invalidate and refetch projects list
       queryClient.invalidateQueries({ queryKey: projectKeys.lists() });
+      // Invalidate dashboard queries (summary and myProjects)
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     },
   });
 };

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { TasksService, type UploadAttachmentRequest } from '@/services/tasks';
+import { dashboardKeys } from './useDashboard';
 import type { Task } from '@/types/task';
 import type {
   CreateTaskRequest,
@@ -97,6 +98,10 @@ export const useCreateTask = () => {
       queryClient.invalidateQueries({
         queryKey: taskKeys.global(),
       });
+      // Invalidate dashboard queries (summary and myTasks)
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
+      });
     },
   });
 };
@@ -124,6 +129,10 @@ export const useUpdateTask = () => {
       // Invalidate project tasks list
       queryClient.invalidateQueries({
         queryKey: taskKeys.list(variables.projectId, {}),
+      });
+      // Invalidate dashboard queries (summary and myTasks)
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
       });
     },
   });
@@ -153,6 +162,10 @@ export const useDeleteTask = () => {
       // Also invalidate global tasks used on Tasks page
       queryClient.invalidateQueries({
         queryKey: taskKeys.global(),
+      });
+      // Invalidate dashboard queries (summary and myTasks)
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
       });
     },
   });
@@ -240,6 +253,10 @@ export const useUpdateTaskStatus = () => {
       queryClient.invalidateQueries({
         queryKey: taskKeys.global(),
       });
+      // Invalidate dashboard queries (summary and myTasks)
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
+      });
     },
   });
 };
@@ -272,6 +289,10 @@ export const useAssignTask = () => {
       queryClient.invalidateQueries({
         queryKey: taskKeys.global(),
       });
+      // Invalidate dashboard queries (summary and myTasks)
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
+      });
     },
   });
 };
@@ -301,6 +322,10 @@ export const useUnassignTask = () => {
       // Also invalidate global tasks used on Tasks page
       queryClient.invalidateQueries({
         queryKey: taskKeys.global(),
+      });
+      // Invalidate dashboard queries (summary and myTasks)
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
       });
     },
   });
@@ -407,6 +432,10 @@ export const useBulkUpdateStatus = () => {
       queryClient.invalidateQueries({
         queryKey: taskKeys.lists(),
       });
+      // Invalidate dashboard queries (summary and myTasks)
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
+      });
     },
   });
 };
@@ -426,6 +455,10 @@ export const useBulkAssignTasks = () => {
       queryClient.invalidateQueries({
         queryKey: taskKeys.lists(),
       });
+      // Invalidate dashboard queries (summary and myTasks)
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
+      });
     },
   });
 };
@@ -444,6 +477,10 @@ export const useBulkDeleteTasks = () => {
       // Also invalidate project-specific queries
       queryClient.invalidateQueries({
         queryKey: taskKeys.lists(),
+      });
+      // Invalidate dashboard queries (summary and myTasks)
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
       });
     },
   });


### PR DESCRIPTION
- Added invalidation for dashboard queries (summary and myProjects) in the useCreateProject, useUpdateProject, and useDeleteProject hooks to ensure the dashboard reflects the latest project data.
- Updated useTasks hooks (useCreateTask, useUpdateTask, useDeleteTask, etc.) to also invalidate dashboard queries, keeping task-related data in sync with the dashboard.

Because keeping the dashboard fresh is as crucial as a punchline landing perfectly! 🎤✨

## What does this PR do?

<!-- Brief description of the changes -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Refactoring (no functional changes)
- [x] ⚡ Performance improvements
- [ ] 🧪 Test additions or updates
- [ ] 🔧 Configuration changes
